### PR TITLE
Allow units to upgrade if acquire horses

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -1131,7 +1131,11 @@
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Rifleman",
 		"hurryCostModifier": 20,
-		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"uniques": [
+			"Personnel",
+			"Can upgrade to [Dragoon]",
+			"Consumes [1] [Weapons]"
+		],
 		"attackSound": "shot"
 	},
 	{

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -351,6 +351,7 @@
 		"obsoleteTech": "Rifling",
 		"uniques": [
 			"Personnel",
+			"Can upgrade to [Horseman]",
 			"[-50]% Strength <vs cities>"
 		],
 		"attackSound": "nonmetalhit"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -570,7 +570,11 @@
 		"requiredTech": "Iron Working",
 		"obsoleteTech": "Rifling",
 		"upgradesTo": "Gunman",
-		"uniques": ["Low Tech", "[+33]% Strength <vs [Low Tech] units>"],
+		"uniques": [
+			"Low Tech",
+			"Can upgrade to [Skirmisher]",
+			"[+33]% Strength <vs [Low Tech] units>"
+		],
 		"attackSound": "arrow"
 	},
 	{
@@ -590,6 +594,7 @@
 		"uniques": [
 			"Low Tech",
 			"Enslaved",
+			"Can upgrade to [Skirmisher]",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"Consumes [1] [Slaves]",
 			"Only available <with [Slaves]>"
@@ -765,7 +770,11 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Soldier",
-		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"uniques": [
+			"Personnel",
+			"Can upgrade to [Hussar]",
+			"Consumes [1] [Weapons]"
+		],
 		"hurryCostModifier": 20,
 		"attackSound": "machinegun"
 	},
@@ -782,7 +791,11 @@
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Soldier",
 		"hurryCostModifier": 20,
-		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"uniques": [
+			"Personnel",
+			"Can upgrade to [Hussar]",
+			"Consumes [1] [Weapons]"
+		],
 		"promotions": ["Forage"],
 		"attackSound": "shot"
 	},
@@ -798,7 +811,11 @@
 		"upgradesTo": "Soldier",
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
-		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"uniques": [
+			"Personnel",
+			"Can upgrade to [Hussar]",
+			"Consumes [1] [Weapons]"
+		],
 		"promotions": ["Hazard Pay", "Tear Gas"],
 		"hurryCostModifier": 20,
 		"attackSound": "shot"
@@ -815,7 +832,11 @@
 		"requiredTech": "The Wheel",
 		"obsoleteTech": "Replaceable Parts",
 		"upgradesTo": "Soldier",
-		"uniques": ["Personnel", "Consumes [1] [Weapons]"],
+		"uniques": [
+			"Personnel",
+			"Can upgrade to [Hussar]",
+			"Consumes [1] [Weapons]"
+		],
 		"hurryCostModifier": 20,
 		"promotions": ["Pride"],
 		"attackSound": "machinegun"

--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -35,6 +35,7 @@
 		"upgradesTo": "Mechanized Worker",
 		"uniques": [
 			"Can build [Land] improvements on tiles",
+			"Can upgrade to [Mounted Worker]",
 			"Automation is a primary action"
 		],
 		"cost": 70
@@ -311,6 +312,7 @@
 		"obsoleteTech": "Rifling",
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Skirmisher]",
 			"[-50]% Strength <vs cities>",
 			"Unable to capture cities"
 		],
@@ -331,6 +333,7 @@
 		"uniques": [
 			"Low Tech",
 			"May capture killed [Barbarian] units <with [33]% chance>",
+			"Can upgrade to [Skirmisher]",
 			"[-50]% Strength <vs cities>",
 			"Unable to capture cities"
 		],
@@ -369,6 +372,7 @@
 		"obsoleteTech": "Rifling",
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Horseman]",
 			"[+50]% Strength <vs [Mounted] units>"
 		],
 		"attackSound": "nonmetalhit"
@@ -386,6 +390,7 @@
 		"obsoleteTech": "Rifling",
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Horseman]",
 			"[+50]% Strength <vs [Mounted] units>",
 			"Earn [50]% of killed [Military] unit's [Strength] as [Faith]"
 		],
@@ -404,6 +409,7 @@
 		"upgradesTo": "Militia",
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Horseman]",
 			"Can instantly construct a [Salvage site] improvement <by consuming this unit>"
 		],
 		"promotions": ["Forage"],
@@ -422,6 +428,7 @@
 		"uniques": [
 			"Low Tech",
 			"Only available <if [Clubhouse] is constructed>",
+			"Can upgrade to [Horseman]",
 			"[+50]% Strength <vs [Mounted] units>"
 		],
 		"promotions": ["Clansman"],
@@ -440,6 +447,7 @@
 		"hurryCostModifier": 20,
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Horseman]",
 			"[+50]% Strength <when defending>"
 		],
 		"promotions": ["Medic I", "[Surveyor] ability"],
@@ -480,6 +488,7 @@
 		"hurryCostModifier": 20,
 		"uniques": [
 			"Low Tech",
+			"Can upgrade to [Horseman]",
 			"[+25]% Strength <vs cities>",
 			"[+25]% Strength <vs [Low Tech] units>"
 		],


### PR DESCRIPTION
Access to preapocalyptic Weapons shapes the Deciv early game. Depending on who you're playing, and where you start, you might not have preapocalyptic Weapons available, so you might be forced to field an army with only iron weapons. But, once you do manage to lay your hands on a cache of preapocalyptic Weapons, you can immediately re-arm your units (to the extent you can afford it).

Early-game Deciv features the basic units with guns but no horses, horses but no guns, both horses and guns, or neither horses nor guns.
```
Spearman -> Militia
   V           V
Horseman -> Hussar

    Archer -> Gunman
      V          V
Skirmisher -> Dragoon
```
The Archer and the Skirmisher are identical except that the Skirmisher is mounted, with the mounted bonuses and penalties (faster, but less effective against enemy Spearmen and cities, and unable to fortify). Same for the Gunman and the Dragoon, and so forth. (The Spearman and Horseman don't *quite* fit the pattern, since the Spearman gets a bonus against mounted units, but, well, yeah, you can't dig in against a cavalry charge when you're using the spears overhand from horseback.)

![image](https://github.com/user-attachments/assets/93d85f07-870d-462e-a126-1c3010f60401)

If you do not start near horses, but later acquire horses, this branch allows you to upgrade your units the same way you can upgrade them when you acquire Weapons.

(You might not always *want* to mount all your units, but this way you *can*.)

Similarly, Workers can be upgraded to Mounted Workers in addition to Mechanized Workers.
![image](https://github.com/user-attachments/assets/78cbf619-1654-4f92-8ca5-a9be0c5313b5)

![image](https://github.com/user-attachments/assets/e05b551c-7cb9-4bea-915b-feef711d699e)

One minor note: this branch leaves *survivor camps* the same, that is, a unit can find weapons in a survivor camp but can never find horses in a survivor camp.

It is possible to make survivor camps randomly choose one of several upgrades, as seen in https://github.com/carriontrooper/Alpha-Frontier/blob/main/jsons/Units.json#L704, but Unciv does not currently have the ability to display a different notification based on which upgrade is randomly selected. We can only specify one notification string, and it's
https://github.com/SpacedOutChicken/Deciv-2/blob/main/jsons/Ruins.json#L56
```
		"notification": "Our unit finds advanced weaponry hidden in the camp!",
```
Thus, this branch leaves survivor camps to match the notification.