### PR TITLE
Restrict upgrading cavalry units if Stable has been lost

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -65,6 +65,7 @@
 			"Mounted",
 			"Can build [Land] improvements on tiles",
 			"Withdraws before melee combat <with [50]% chance>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>",
 			"Automation is a primary action"
 		],
@@ -605,6 +606,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-25]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 		],
 		"hurryCostModifier": 20,
@@ -630,6 +632,7 @@
 			"[+50]% Strength <vs [Low Tech] units>",
 			"[-25]% Strength <vs cities> <when attacking>",
 			"Only available <if [Clubhouse] is constructed>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 		],
 		"hurryCostModifier": 20,
@@ -654,6 +657,7 @@
 			"Can move after attacking",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 		],
 		"hurryCostModifier": 20,
@@ -679,6 +683,7 @@
 			"Can move after attacking",
 			"[+33]% Strength <vs [Low Tech] units>",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>",
 			"Consumes [1] [Slaves]"
 		],
@@ -1308,6 +1313,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>",
 			"Consumes [1] [Weapons]"
 		],
@@ -1329,6 +1335,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 		],
 		"hurryCostModifier": 20,
@@ -1351,6 +1358,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 			],
 		"promotions": ["Pursuit"],
@@ -1375,6 +1383,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>",
 			"Consumes [1] [Weapons]"
 		],
@@ -1398,6 +1407,7 @@
 			"No defensive terrain bonus",
 			"Can move after attacking",
 			"[-33]% Strength <vs cities> <when attacking>",
+			"Only available <if [Stable] is constructed>",
 			"Can only be built <in cities with a [Stable]>"
 		],
 		"hurryCostModifier": 20,


### PR DESCRIPTION
This branch adds the Unique "Only available <if [Stable] is constructed>" to all units with the "Can only be built <in cities with a [Stable]>" Unique.

Per https://yairm210.github.io/Unciv/Modders/uniques, the difference between the two is that "Only available" will also block Upgrade actions, whereas "Can only be built" will not.

With this, it's impossible to upgrade a Horseman to a Hussar (for example) if the city with the Stable has been lost since the Horseman was constructed.

One note: this uses the "is constructed" conditional, like the Mechanized Worker and Legion and Marine and NBC Infantry and Spec Ops and Black Ops and Cannon and Anti-Tank Gun and Artillery and Machine Gun and Anti-Aircraft Gun and Armored Car and Tank and Rocket Artillery and Missile Vehicle and Helicopter and Fighter and Bomber and Light Drone and Attack Boat and Destroyer and Battleship and Missile Cruiser and Carrier and Submarine. As in those cases, this means that units can be upgraded anywhere in your territory, as long as you have the building constructed *somewhere*. (The conditionals "<in cities with a [Stable]>", "<in [Horses] tiles>", "<in [Pasture] tiles>". "<in tiles adjacent to [Horses] tiles>". "<in tiles adjacent to [Pasture] tiles>" , and "<within [1] tiles of a [Pasture]>" do not seem to work for restricting further.) (https://yairm210.github.io/Unciv/Modders/uniques)