### PR TITLE
The Green Palace temporary fix

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -1232,7 +1232,7 @@
 		"happiness": 4,
 		"greatPersonPoints": {"Great Engineer": 1},
 		"uniques": [
-			"Creates a [Factory farm] improvement on a specific tile",
+			"Free [Great Farmer] appears",
 			"[+4 Food] from every [Factory farm]"
 		],
 		"requiredTech": "Ecotheory",


### PR DESCRIPTION
This pull request replaces the Specific Tile condition for a free Great Farmer. This is not meant to be a permanent fix. Another simple solution could be to have a Great Botanist unit that can spawn only from the Green Palace wonder and can only make a Factory Farm building.

I made this because of a bug I encountered, you can see it here: https://github.com/SpacedOutChicken/Deciv-2/issues/16